### PR TITLE
[do-not-merge] enable log on celadon

### DIFF
--- a/_studio/shared/mfx_trace/src/mfx_trace.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace.cpp
@@ -313,7 +313,7 @@ mfxTraceU32 mfx_trace_get_category_index(mfxTraceChar* category, mfxTraceU32& in
 
 inline bool MFXTrace_IsPrintableCategoryAndLevel(mfxTraceU32 m_OutputInitilized, mfxTraceU32 level)
 {
-    bool logFlag = false;
+    bool logFlag = true;
     if (m_OutputInitilized == MFX_TRACE_OUTPUT_TEXTLOG) {
 #ifndef NDEBUG
         if (g_Level == MFX_TXTLOG_LEVEL_MAX)
@@ -400,7 +400,7 @@ mfxTraceU32 MFXTrace_Init()
         g_OutputMode = 0;
         for (i = 0; i < sizeof(g_TraceAlgorithms)/sizeof(mfxTraceAlgorithm); ++i)
         {
-            if (output_mode & g_TraceAlgorithms[i].m_OutputMask)
+            if (1)
             {
                 sts = g_TraceAlgorithms[i].m_InitFn();
                 if (sts == 0)
@@ -484,7 +484,7 @@ mfxTraceU32 MFXTrace_DebugMessage(mfxTraceStaticHandle *static_handle,
     va_start(args, format);
     for (i = 0; i < sizeof(g_TraceAlgorithms)/sizeof(mfxTraceAlgorithm); ++i)
     {
-        if (g_OutputMode & g_TraceAlgorithms[i].m_OutputInitilized)
+        if (1)
         {
             if (!MFXTrace_IsPrintableCategoryAndLevel(g_TraceAlgorithms[i].m_OutputInitilized, level)) continue;
 

--- a/_studio/shared/mfx_trace/src/mfx_trace_textlog.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace_textlog.cpp
@@ -24,7 +24,7 @@
 extern "C"
 {
 
-#define MFT_TRACE_PATH_TO_TEMP_LIBLOG MFX_TRACE_STRING("/tmp/mfxlib.log")
+#define MFT_TRACE_PATH_TO_TEMP_LIBLOG MFX_TRACE_STRING("/data/local/tmp/mfx-gen.log")
 
 #include <stdio.h>
 #include "mfx_trace_utils.h"
@@ -91,8 +91,8 @@ mfxTraceU32 MFXTraceTextLog_Init()
     sts = MFXTraceTextLog_Close();
     if (!sts) sts = MFXTraceTextLog_GetRegistryParams();
     std::string StrPid = "/mfxlib_Pid";
-    std::string filename_path = VplLogPath + StrPid + std::to_string(getpid()) + "_Tid" + std::to_string(pthread_self()) + ".log";
-    strncpy(g_mfxTracePrintfFileName,filename_path.c_str(), MAX_PATH - 1);
+    // std::string filename_path = VplLogPath + StrPid + std::to_string(getpid()) + "_Tid" + std::to_string(pthread_self()) + ".log";
+    // strncpy(g_mfxTracePrintfFileName,filename_path.c_str(), MAX_PATH - 1);
     g_mfxTracePrintfFileName[MAX_PATH - 1] = 0;
 
     if (!sts)

--- a/_studio/shared/mfx_trace/src/mfx_trace_utils_linux.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace_utils_linux.cpp
@@ -74,7 +74,7 @@ FILE* mfx_trace_open_conf_file(const char* name)
     std::stringstream ss;
 
 #if defined(ANDROID)
-    const char* home = "/data/data/com.intel.vtune/mediasdk";
+    const char* home = "/data/local";
 #else
     const char* home = getenv("HOME");
 #endif


### PR DESCRIPTION
version: 24.1.5

1. apply this patch, build (`make libmfx-ge`) and replace it.
2. create a named ".mfx_trace" file in /data/local in android with the following content: `Output=0x01`
3. make sure your program has permission to r/w in /data/local/tmp, e.g. add root in hardware.intel.media.c2@1.0-service.rc
4. reboot android.
5. find the log file in /data/local/tmp/mfx-gen.log