### PR TITLE
Make decoding output bit format configurable

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -293,6 +293,7 @@ mfxStatus VideoDECODEAV1::Init(mfxVideoParam* par)
 
     m_core->GetVA((mfxHDL*)&m_va, MFX_MEMTYPE_FROM_DECODE);
     vp.pVideoAccelerator = m_va;
+    vp.color_config.BitDepth = FourCcBitDepth(par->mfx.FrameInfo.FourCC);
 
     ConvertMFXParamsToUMC(par, &vp);
     vp.info.profile = av1_mfx_profile_to_native_profile(par->mfx.CodecProfile);

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -1141,6 +1141,11 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1
 
         VP9DecoderFrame frameInfo = m_frameInfo;
         sts = DecodeFrameHeader(bs, frameInfo);
+
+        // XXX: Overwrite profile and bit_depth from mfxparam so that we can configure
+        // the output bit format.
+        frameInfo.profile = m_vPar.mfx.CodecProfile - 1;
+        frameInfo.bit_depth = m_vPar.mfx.FrameInfo.BitDepthLuma;
         MFX_CHECK_STS(sts);
 
         MFX_VP9_Utility::FillVideoParam(m_core->GetPlatformType(), frameInfo, m_vPar);

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -276,18 +276,6 @@ public:
         }
     }
 
-    void CompleteCurFrame(UMC::FrameMemID frameId)
-    {
-        auto find_it = std::find_if(m_submittedFrames.begin(), m_submittedFrames.end(),
-            [frameId](const UMC_VP9_DECODER::VP9DecoderFrame & item) { return item.currFrame == frameId; });
-
-        if (find_it != m_submittedFrames.end() && find_it->isDecoded)
-        {
-            UnLockResources(*find_it);
-            m_submittedFrames.erase(find_it);
-        }
-    }
-
     void CompleteFrames()
     {
         for (auto it = m_submittedFrames.begin(); it != m_submittedFrames.end(); )
@@ -935,7 +923,6 @@ mfxStatus MFX_CDECL VP9DECODERoutine(void *p_state, void * /* pp_param */, mfxU3
             decoder.m_surface_source->SetFreeSurfaceAllowedFlag(false);
         }
         decoder.m_framesStorage->DecodeFrame(data.currFrameId);
-        decoder.m_framesStorage->CompleteCurFrame(data.currFrameId);
 
         return MFX_ERR_NONE;
     }
@@ -973,7 +960,6 @@ mfxStatus MFX_CDECL VP9DECODERoutine(void *p_state, void * /* pp_param */, mfxU3
     if (data.currFrameId != -1)
         decoder.m_surface_source->DecreaseReference(data.currFrameId);
     decoder.m_framesStorage->DecodeFrame(data.currFrameId);
-    decoder.m_framesStorage->CompleteCurFrame(data.currFrameId);
 
     return MFX_TASK_DONE;
 }

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_va_packer.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_va_packer.h
@@ -53,12 +53,15 @@ public:
 
     virtual void PackAU(std::vector<TileSet>&, AV1DecoderFrame const&, bool) = 0;
     virtual void RegisterAnchor(UMC::FrameMemID) = 0;
+    mfxU16 GetBitDepth() { return m_bitDepth; }
+    void SetBitDepth(mfxU16 bitDepth) { m_bitDepth = bitDepth; }
 
     static Packer* CreatePacker(UMC::VideoAccelerator * va);
 
 protected:
 
     UMC::VideoAccelerator *m_va;
+    mfxU16 m_bitDepth = 8;
 };
 
 } // namespace UMC_AV1_DECODER

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
@@ -57,6 +57,7 @@ namespace UMC_AV1_DECODER
 
         va = dp->pVideoAccelerator;
         packer.reset(Packer::CreatePacker(va));
+        packer->SetBitDepth(dp->color_config.BitDepth);
 
         uint32_t dpb_size = std::max(params.async_depth + TOTAL_REFS, 8u);
 

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
@@ -180,8 +180,7 @@ namespace UMC_AV1_DECODER
         seqInfo.film_grain_params_present = sh.film_grain_param_present;
 
         picParam.matrix_coefficients = sh.color_config.matrix_coefficients;
-        picParam.bit_depth_idx = (sh.color_config.BitDepth == 10) ? 1 :
-            (sh.color_config.BitDepth == 12) ? 2 : 0;
+        picParam.bit_depth_idx = (m_bitDepth == 10) ? 1 : (m_bitDepth == 12) ? 2 : 0;
         picParam.order_hint_bits_minus_1 = (uint8_t)sh.order_hint_bits_minus1;
 
         // fill pic params

--- a/_studio/shared/umc/codec/h265_dec/include/platform/umc_h265_va_packer_vaapi_g9.hpp
+++ b/_studio/shared/umc/codec/h265_dec/include/platform/umc_h265_va_packer_vaapi_g9.hpp
@@ -181,8 +181,6 @@ namespace UMC_HEVC_DECODER
             pic_fields.NoBiPredFlag                                          = 0;
 
             pp->sps_max_dec_pic_buffering_minus1                             = (uint8_t)(sps->sps_max_dec_pic_buffering[sh->nuh_temporal_id] - 1);
-            pp->bit_depth_luma_minus8                                        = (uint8_t)(sps->bit_depth_luma - 8);
-            pp->bit_depth_chroma_minus8                                      = (uint8_t)(sps->bit_depth_chroma - 8);
             pp->pcm_sample_bit_depth_luma_minus1                             = (uint8_t)(sps->pcm_sample_bit_depth_luma - 1);
             pp->pcm_sample_bit_depth_chroma_minus1                           = (uint8_t)(sps->pcm_sample_bit_depth_chroma - 1);
             pp->log2_min_luma_coding_block_size_minus3                       = (uint8_t)(sps->log2_min_luma_coding_block_size- 3);
@@ -441,6 +439,11 @@ namespace UMC_HEVC_DECODER
 
                 VAPictureParameterBufferHEVC* pp = nullptr;
                 PeekParamsBuffer(m_va, &pp);
+                // XXX: Get bit_depth from mfxParam instead of bitstream so that we can configure
+                // the output bit format.
+                pp->bit_depth_luma_minus8 = color_format2bit_depth(supplier->GetColorformat()) - 8;
+                pp->bit_depth_chroma_minus8 = color_format2bit_depth(supplier->GetColorformat()) - 8;
+
                 PackPicHeader(m_va, frame, dpb, pp);
             }
 

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
@@ -1492,6 +1492,27 @@ inline size_t CalculateSuggestedSize(const H265SeqParamSet * sps)
     return 2*size;
 }
 
+inline
+mfxU16 color_format2bit_depth(UMC::ColorFormat format)
+{
+    switch (format)
+    {
+        case UMC::NV12:
+        case UMC::YUY2:
+        case UMC::AYUV: return 8;
+
+        case UMC::P010:
+        case UMC::Y210:
+        case UMC::Y410:  return 10;
+
+        case UMC::P016:
+        case UMC::Y216:
+        case UMC::Y416:  return 12;
+
+        default:         return 0;
+    }
+}
+
 } // end namespace UMC_HEVC_DECODER
 
 #endif // H265_GLOBAL_ROM_H

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_task_supplier.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_task_supplier.h
@@ -374,6 +374,11 @@ public:
         return &m_ObjHeap;
     }
 
+    UMC::ColorFormat GetColorformat()
+    {
+        return m_initializationParams.info.color_format;
+    }
+
 protected:
 
     // Include a new slice into a set of frame slices
@@ -412,7 +417,8 @@ protected:
     virtual UMC::Status AddOneFrame(UMC::MediaData * pSource);
 
     // Allocate frame internals
-    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet, const H265PicParamSet *pPicParamSet);
+    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions,
+        const H265SeqParamSet* pSeqParamSet, const H265PicParamSet *pPicParamSet, UMC::ColorFormat colorFormat);
 
     // Decode a bitstream header NAL unit
     virtual UMC::Status DecodeHeaders(UMC::MediaDataEx *nalUnit);

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
@@ -59,7 +59,8 @@ public:
 
 
 protected:
-    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet, const H265PicParamSet *pPicParamSet);
+    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet,
+                                            const H265PicParamSet *pPicParamSet, UMC::ColorFormat colorFormat);
 
     virtual void InitFrameCounter(H265DecoderFrame * pFrame, const H265Slice *pSlice);
 
@@ -92,9 +93,10 @@ public:
 
 protected:
 
-    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet, const H265PicParamSet * pps)
+    virtual UMC::Status AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet,
+                                        const H265PicParamSet * pps, UMC::ColorFormat colorFormat)
     {
-        UMC::Status ret = BaseClass::AllocateFrameData(pFrame, dimensions, pSeqParamSet, pps);
+        UMC::Status ret = BaseClass::AllocateFrameData(pFrame, dimensions, pSeqParamSet, pps, colorFormat);
 
         if (ret == UMC::UMC_OK)
         {

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -2454,12 +2454,12 @@ UMC::Status TaskSupplier_H265::InitFreeFrame(H265DecoderFrame * pFrame, const H2
 }
 
 // Allocate frame internals
-UMC::Status TaskSupplier_H265::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet, const H265PicParamSet *pPicParamSet)
+UMC::Status TaskSupplier_H265::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet,
+                                                const H265PicParamSet *pPicParamSet, UMC::ColorFormat colorFormat)
 {
-    UMC::ColorFormat color_format = pFrame->GetColorFormat();
-        //(ColorFormat) pSeqParamSet->chroma_format_idc;
+    UMC::ColorFormat color_format = colorFormat;
     UMC::VideoDataInfo info;
-    int32_t bit_depth = pSeqParamSet->need16bitOutput ? 10 : 8;
+    int32_t bit_depth = color_format2bit_depth(color_format);
     info.Init(dimensions.width, dimensions.height, color_format, bit_depth);
 
     UMC::FrameMemID frmMID;
@@ -2520,7 +2520,8 @@ H265DecoderFrame * TaskSupplier_H265::AllocateNewFrame(const H265Slice *pSlice)
         return 0;
     }
 
-    umcRes = AllocateFrameData(pFrame, pFrame->lumaSize(), pSlice->GetSeqParam(), pSlice->GetPicParam());
+    umcRes = AllocateFrameData(pFrame, pFrame->lumaSize(), pSlice->GetSeqParam(), pSlice->GetPicParam(),
+                        m_initializationParams.info.color_format);
     if (umcRes != UMC::UMC_OK)
     {
         return 0;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
@@ -142,11 +142,12 @@ void VATaskSupplier::InitFrameCounter(H265DecoderFrame * pFrame, const H265Slice
     TaskSupplier_H265::InitFrameCounter(pFrame, pSlice);
 }
 
-UMC::Status VATaskSupplier::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet, const H265PicParamSet *)
+UMC::Status VATaskSupplier::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize dimensions, const H265SeqParamSet* pSeqParamSet,
+                                            const H265PicParamSet *, UMC::ColorFormat colorFormat)
 {
-    UMC::ColorFormat chroma_format_idc = pFrame->GetColorFormat();
+    UMC::ColorFormat chroma_format_idc = colorFormat;
     UMC::VideoDataInfo info;
-    int32_t bit_depth = pSeqParamSet->need16bitOutput ? 10 : 8;
+    int32_t bit_depth = color_format2bit_depth(chroma_format_idc);
     info.Init(dimensions.width, dimensions.height, chroma_format_idc, bit_depth);
 
     UMC::FrameMemID frmMID;


### PR DESCRIPTION
In order to pass Cts#testDefaultOutputColorFormat, we need to determine the output bit format by mfxparam instead of bitstream.

Tracked-On: OAM-119832