### PR TITLE
Revert "[Decode] Complete cur frame in child thread to unlock res (#6…

### DIFF
--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -276,18 +276,6 @@ public:
         }
     }
 
-    void CompleteCurFrame(UMC::FrameMemID frameId)
-    {
-        auto find_it = std::find_if(m_submittedFrames.begin(), m_submittedFrames.end(),
-            [frameId](const UMC_VP9_DECODER::VP9DecoderFrame & item) { return item.currFrame == frameId; });
-
-        if (find_it != m_submittedFrames.end() && find_it->isDecoded)
-        {
-            UnLockResources(*find_it);
-            m_submittedFrames.erase(find_it);
-        }
-    }
-
     void CompleteFrames()
     {
         for (auto it = m_submittedFrames.begin(); it != m_submittedFrames.end(); )
@@ -935,7 +923,6 @@ mfxStatus MFX_CDECL VP9DECODERoutine(void *p_state, void * /* pp_param */, mfxU3
             decoder.m_surface_source->SetFreeSurfaceAllowedFlag(false);
         }
         decoder.m_framesStorage->DecodeFrame(data.currFrameId);
-        decoder.m_framesStorage->CompleteCurFrame(data.currFrameId);
 
         return MFX_ERR_NONE;
     }
@@ -973,7 +960,6 @@ mfxStatus MFX_CDECL VP9DECODERoutine(void *p_state, void * /* pp_param */, mfxU3
     if (data.currFrameId != -1)
         decoder.m_surface_source->DecreaseReference(data.currFrameId);
     decoder.m_framesStorage->DecodeFrame(data.currFrameId);
-    decoder.m_framesStorage->CompleteCurFrame(data.currFrameId);
 
     return MFX_TASK_DONE;
 }


### PR DESCRIPTION
…509)"

This reverts commit c40736a486913e4e604dbdbae042fde3d2226387. This patch make the decoded VP9 CBR frame in unexpected order.

Tracked-On: OAM-118913