### PR TITLE
Return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM once parameter is changed

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -1258,6 +1258,7 @@ mfxStatus VideoDECODEH264::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *
                 }
 
                 MFX_CHECK(umcRes != UMC::UMC_NTF_NEW_RESOLUTION, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+                MFX_CHECK(sts != MFX_WRN_VIDEO_PARAM_CHANGED, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
             }
 
             if (umcRes == UMC::UMC_ERR_INVALID_STREAM)

--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -1050,7 +1050,8 @@ mfxStatus VideoDECODEH265::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *
             {
                 if (!m_isFirstRun)
                 {
-                    sts = MFX_WRN_VIDEO_PARAM_CHANGED;
+                    //sts = MFX_WRN_VIDEO_PARAM_CHANGED;
+		    sts = MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
                 }
                 else
                 {


### PR DESCRIPTION
Return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM once parameter is changed
For AVC and HEVC decoder, once parameter including colorAspect and
bitDepth is changed, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM is returned.
In order to inform c2-plugin to re-init decoder for parameter changes