### PR TITLE
Once parameter is changed, return MFX_WRN_VIDEO_PARAM_CHANGED

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -1264,6 +1264,7 @@ mfxStatus VideoDECODEH264::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *
                 }
 
                 MFX_CHECK(umcRes != UMC::UMC_NTF_NEW_RESOLUTION, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+                MFX_CHECK(sts != MFX_WRN_VIDEO_PARAM_CHANGED, MFX_WRN_VIDEO_PARAM_CHANGED);
             }
 
             if (umcRes == UMC::UMC_ERR_INVALID_STREAM)


### PR DESCRIPTION
In H264 decoder, the parameter_changes event will be skipped. when Color-Aspect and Bit-Depth is changed, the expected event MFX_WRN_VIDEO_PARAM_CHANGED is not returned, and skipped. Has to return it for this case.

Tracked-On: OAM-130444